### PR TITLE
Fix FakeSocket tests: null socket object if tests aren't run sequentially.

### DIFF
--- a/lib/fsr/fake_socket.rb
+++ b/lib/fsr/fake_socket.rb
@@ -49,8 +49,12 @@ require 'bacon'
 Bacon.summary_at_exit
 
 describe FSR::FakeSocket do
-  it 'can be initialized' do
+
+  before do 
     @socket = FSR::FakeSocket.new('google.com', 80)
+  end
+
+  it 'can be initialized' do
     @socket.should.not.be.nil
   end
 


### PR DESCRIPTION
fake_socket.rb specs get run by rspec3 and fail due to @socket not being defined in each test. Moved instantiation into a before block. 
